### PR TITLE
Newtonsoft.Json reference from Nuget, compilation warnings fixed

### DIFF
--- a/1.0/.gitignore
+++ b/1.0/.gitignore
@@ -1,0 +1,40 @@
+#Autosave files
+*~
+
+#build
+[Oo]bj/
+[Bb]in/
+packages/
+TestResults/
+
+# globs
+Makefile.in
+*.DS_Store
+*.sln.cache
+*.suo
+*.cache
+*.pidb
+*.userprefs
+*.usertasks
+config.log
+config.make
+config.status
+aclocal.m4
+install-sh
+autom4te.cache/
+*.user
+*.tar.gz
+tarballs/
+test-results/
+Thumbs.db
+
+#Mac bundle stuff
+*.dmg
+*.app
+
+#resharper
+*_Resharper.*
+*.Resharper
+
+#dotCover
+*.dotCover

--- a/1.0/App42-Xamarin-SDK/Album.cs
+++ b/1.0/App42-Xamarin-SDK/Album.cs
@@ -214,7 +214,7 @@ namespace com.shephertz.app42.paas.sdk.csharp.gallery
             /// Returns the Album Response in JSON format.
             /// </summary>
             /// <returns>The response in JSON format.</returns>
-            public String ToString()
+            public override String ToString()
             {
                 return " name : " + name + " : description : " + description + " : url : " + url + " : tinyUrl : " + tinyUrl + " : thumbNailUrl : " + thumbNailUrl + " :  thumbNailTinyUrl  : " + thumbNailTinyUrl + " : tagList : " + tagList;
             }

--- a/1.0/App42-Xamarin-SDK/App42-Xamarin-SDK.csproj
+++ b/1.0/App42-Xamarin-SDK/App42-Xamarin-SDK.csproj
@@ -31,7 +31,7 @@
     <Reference Include="System" />
     <Reference Include="System.Web" />
     <Reference Include="Newtonsoft.Json">
-      <HintPath>C:\Users\Suyash\Downloads\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -123,5 +123,6 @@
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>
     <None Include="Lib\Newtonsoft.Json.dll" />
+    <None Include="packages.config" />
   </ItemGroup>
 </Project>

--- a/1.0/App42-Xamarin-SDK/App42BadParameterException.cs
+++ b/1.0/App42-Xamarin-SDK/App42BadParameterException.cs
@@ -29,7 +29,7 @@ namespace com.shephertz.app42.paas.sdk.csharp
         /// Sets the HttpErrorCode for the Exception
         /// </summary>
         /// <param name="httpErrorCode"> The http error code e.g. 404, 500, 401 etc.</param>
-        public void SetHttpErrorCode(int httpErrorCode)
+        public override void SetHttpErrorCode(int httpErrorCode)
         {
             this.httpErrorCode = httpErrorCode;
         }
@@ -38,7 +38,7 @@ namespace com.shephertz.app42.paas.sdk.csharp
         /// Gets the HttpErrorCode for the Exception e.g. 404, 500, 401 etc.
         /// </summary>
 
-        public int GetHttpErrorCode()
+        public override int GetHttpErrorCode()
         {
             return this.httpErrorCode;
         }
@@ -50,7 +50,7 @@ namespace com.shephertz.app42.paas.sdk.csharp
         /// This error code can help App developers to take decisions and take action
         /// when a particular error occurs for a service
         /// </param>
-        public void SetAppErrorCode(int appErrorCode)
+        public override void SetAppErrorCode(int appErrorCode)
         {
             this.appErrorCode = appErrorCode;
         }
@@ -60,7 +60,7 @@ namespace com.shephertz.app42.paas.sdk.csharp
         /// when a particular error occurs for a service 
         /// </summary>
 
-        public int GetAppErrorCode()
+        public override int GetAppErrorCode()
         {
             return this.appErrorCode;
         }

--- a/1.0/App42-Xamarin-SDK/App42Exception.cs
+++ b/1.0/App42-Xamarin-SDK/App42Exception.cs
@@ -26,7 +26,7 @@ namespace com.shephertz.app42.paas.sdk.csharp
         /// Sets the HttpErrorCode for the Exception
         /// </summary>
         /// <param name="httpErrorCode"> httpErrorCode The http error code e.g. 404, 500, 401 etc.</param>
-        public void SetHttpErrorCode(int    httpErrorCode)
+        public virtual void SetHttpErrorCode(int    httpErrorCode)
         {
             this.httpErrorCode = httpErrorCode;
         }
@@ -35,7 +35,7 @@ namespace com.shephertz.app42.paas.sdk.csharp
         /// </summary>
         /// <returns></returns>
      
-        public int    GetHttpErrorCode()
+        public virtual int GetHttpErrorCode()
         {
             return this.httpErrorCode;
         }
@@ -48,7 +48,7 @@ namespace com.shephertz.app42.paas.sdk.csharp
          /// when a particular error occurs for a service
          /// </param>
          
-        public void SetAppErrorCode(int    appErrorCode)
+        public virtual void SetAppErrorCode(int    appErrorCode)
         {
             this.appErrorCode = appErrorCode;
         }
@@ -59,7 +59,7 @@ namespace com.shephertz.app42.paas.sdk.csharp
         /// </summary>
         /// <returns></returns>
           
-        public int    GetAppErrorCode()
+        public virtual int GetAppErrorCode()
         {
             return this.appErrorCode;
         }

--- a/1.0/App42-Xamarin-SDK/App42LimitException.cs
+++ b/1.0/App42-Xamarin-SDK/App42LimitException.cs
@@ -31,7 +31,7 @@ namespace com.shephertz.app42.paas.sdk.csharp
         /// </summary>
         /// <param name="httpErrorCode">httpErrorCode The http error code e.g. 404, 500, 401 etc.</param>
 
-        public void SetHttpErrorCode(int httpErrorCode)
+        public override void SetHttpErrorCode(int httpErrorCode)
         {
             this.httpErrorCode = httpErrorCode;
         }
@@ -40,7 +40,7 @@ namespace com.shephertz.app42.paas.sdk.csharp
         /// Gets the HttpErrorCode for the Exception e.g. 404, 500, 401 etc.
         /// </summary>
 
-        public int GetHttpErrorCode()
+        public override int GetHttpErrorCode()
         {
             return this.httpErrorCode;
         }
@@ -52,7 +52,7 @@ namespace com.shephertz.app42.paas.sdk.csharp
         /// This error code can help App developers to take decisions and take action 
         /// when a particular error occurs for a service
         /// </param>
-        public void SetAppErrorCode(int appErrorCode)
+        public override void SetAppErrorCode(int appErrorCode)
         {
             this.appErrorCode = appErrorCode;
         }
@@ -63,7 +63,7 @@ namespace com.shephertz.app42.paas.sdk.csharp
         /// when a particular error occurs for a service 
         /// </summary>
 
-        public int GetAppErrorCode()
+        public override int GetAppErrorCode()
         {
             return this.appErrorCode;
         }

--- a/1.0/App42-Xamarin-SDK/App42NotFoundException.cs
+++ b/1.0/App42-Xamarin-SDK/App42NotFoundException.cs
@@ -29,14 +29,14 @@ namespace com.shephertz.app42.paas.sdk.csharp
         /// Sets the HttpErrorCode for the Exception
         /// </summary>
         /// <param name="httpErrorCode"> The http error code e.g. 404, 500, 401 etc.</param>
-        public void SetHttpErrorCode(int httpErrorCode)
+        public override void SetHttpErrorCode(int httpErrorCode)
         {
             this.httpErrorCode = httpErrorCode;
         }
         /// <summary>
         /// Gets the HttpErrorCode for the Exception e.g. 404, 500, 401 etc.
         /// </summary>
-        public int GetHttpErrorCode()
+        public override int GetHttpErrorCode()
         {
             return this.httpErrorCode;
         }
@@ -48,7 +48,7 @@ namespace com.shephertz.app42.paas.sdk.csharp
         /// This error code can help App developers to take decisions and take action
         /// when a particular error occurs for a service
         /// </param>
-        public void SetAppErrorCode(int appErrorCode)
+        public override void SetAppErrorCode(int appErrorCode)
         {
             this.appErrorCode = appErrorCode;
         }
@@ -57,7 +57,7 @@ namespace com.shephertz.app42.paas.sdk.csharp
         /// This error code can help App developers to take decisions and take action
         /// when a particular error occurs for a service 
         /// </summary>
-        public int GetAppErrorCode()
+        public override int GetAppErrorCode()
         {
             return this.appErrorCode;
         }

--- a/1.0/App42-Xamarin-SDK/App42SecurityException.cs
+++ b/1.0/App42-Xamarin-SDK/App42SecurityException.cs
@@ -37,7 +37,7 @@ namespace com.shephertz.app42.paas.sdk.csharp
         /// <summary>
         /// Gets the HttpErrorCode for the Exception e.g. 404, 500, 401 etc.
         /// </summary>
-		public int GetHttpErrorCode()
+        public override int GetHttpErrorCode()
         {
             return this.httpErrorCode;
         }
@@ -49,7 +49,7 @@ namespace com.shephertz.app42.paas.sdk.csharp
         /// This error code can help App developers to take decisions and take action
         /// when a particular error occurs for a service
         /// </param>
-        public void SetAppErrorCode(int appErrorCode)
+        public override void SetAppErrorCode(int appErrorCode)
         {
             this.appErrorCode = appErrorCode;
         }
@@ -58,7 +58,7 @@ namespace com.shephertz.app42.paas.sdk.csharp
         ///  This error code can help App developers to take decisions and take action
         ///  when a particular error occurs for a service 
         /// </summary>
-        public int GetAppErrorCode()
+        public override int GetAppErrorCode()
         {
             return this.appErrorCode;
         }

--- a/1.0/App42-Xamarin-SDK/Cart.cs
+++ b/1.0/App42-Xamarin-SDK/Cart.cs
@@ -194,7 +194,7 @@ namespace com.shephertz.app42.paas.sdk.csharp.shopping
                 this.totalAmount = totalAmount;
             }
 
-            public String ToString()
+            public override String ToString()
             {
                 return " name : " + name + " : itemId : " + itemId
                         + " : price : " + price + " : quantity : " + quantity;

--- a/1.0/App42-Xamarin-SDK/Catalogue.cs
+++ b/1.0/App42-Xamarin-SDK/Catalogue.cs
@@ -84,7 +84,7 @@ namespace com.shephertz.app42.paas.sdk.csharp.shopping
                 this.itemList = itemList;
             }
 
-            public String ToString()
+            public override String ToString()
             {
                 return " name : " + name + " : description : " + description;
             }
@@ -152,7 +152,7 @@ namespace com.shephertz.app42.paas.sdk.csharp.shopping
                     this.price = price;
                 }
 
-                public String ToString()
+                public override String ToString()
                 {
                     return " itemId : " + itemId + " : name : " + name
                             + " : description : " + description + " : url : " + url + " : price : " + price;

--- a/1.0/App42-Xamarin-SDK/Email.cs
+++ b/1.0/App42-Xamarin-SDK/Email.cs
@@ -108,7 +108,7 @@ namespace com.shephertz.app42.paas.sdk.csharp.email
                 this.ssl = ssl;
             }
 
-            public String ToString()
+            public override String ToString()
             {
                 return "Email : " + emailId + " : Host  : " + host + " : port : " + port + " : ssl : " + ssl;
             }

--- a/1.0/App42-Xamarin-SDK/Geo.cs
+++ b/1.0/App42-Xamarin-SDK/Geo.cs
@@ -110,7 +110,7 @@ namespace com.shephertz.app42.paas.sdk.csharp.geo
                 this.marker = marker;
             }
 
-            public String ToString()
+            public override String ToString()
             {
                 return "Lat : " + lat + " : Lang : " + lng + " : Marker : " + marker;
             }

--- a/1.0/App42-Xamarin-SDK/Log.cs
+++ b/1.0/App42-Xamarin-SDK/Log.cs
@@ -36,6 +36,7 @@ namespace com.shephertz.app42.paas.sdk.csharp.log
             {
                 this.message = message;
             }
+            #warning this one hides .net default method .GetType()!
             public String GetType()
             {
                 return type;
@@ -60,7 +61,7 @@ namespace com.shephertz.app42.paas.sdk.csharp.log
             {
                 this.module = appModule;
             }
-            public String ToString()
+            public override String ToString()
             {
                 return "Message : " + this.message + " : type : " + this.type + " : AppModule : " + this.module + " : logTime : " + this.logTime;
             }

--- a/1.0/App42-Xamarin-SDK/PushNotification.cs
+++ b/1.0/App42-Xamarin-SDK/PushNotification.cs
@@ -32,6 +32,7 @@ namespace com.shephertz.app42.paas.sdk.csharp.pushNotification
         {
             this.deviceToken = deviceToken;
         }
+        #warning this one hides .net default method .GetType()!
         public String GetType()
         {
             return type;

--- a/1.0/App42-Xamarin-SDK/Query.cs
+++ b/1.0/App42-Xamarin-SDK/Query.cs
@@ -60,7 +60,7 @@ namespace com.shephertz.app42.paas.sdk.csharp.storage
                 return jsonArray.ToString();
             }
         }
-
+        #warning this one hides .net default method .GetType()!
         public Object GetType()
         {
             if (jsonObject != null)

--- a/1.0/App42-Xamarin-SDK/Queue.cs
+++ b/1.0/App42-Xamarin-SDK/Queue.cs
@@ -78,7 +78,7 @@ namespace com.shephertz.app42.paas.sdk.csharp.message
                 this.messageId = messageId;
             }
 
-            public String ToString()
+            public override String ToString()
             {
                 return " correlationId : " + correlationId + " : payLoad : " + payLoad + " : messageId : " + messageId;
             }

--- a/1.0/App42-Xamarin-SDK/Recommender.cs
+++ b/1.0/App42-Xamarin-SDK/Recommender.cs
@@ -70,7 +70,7 @@ namespace com.shephertz.app42.paas.sdk.csharp.recommend
                 this.value = value;
             }
 
-            public String ToString()
+            public override String ToString()
             {
                 return "userId : " + this.userId + ": item : " + this.item + " : value : " + this.value;
             }

--- a/1.0/App42-Xamarin-SDK/Storage.cs
+++ b/1.0/App42-Xamarin-SDK/Storage.cs
@@ -115,7 +115,7 @@ namespace com.shephertz.app42.paas.sdk.csharp.storage
             /// Returns the Storage Response in JSON format.
             /// </summary>
             /// <returns>The response in JSON format.</returns>
-            public String ToString()
+            public override String ToString()
             {
                 if (this.docId != null && this.jsonDoc != null)
                     return this.docId + " : " + this.jsonDoc;

--- a/1.0/App42-Xamarin-SDK/Upload.cs
+++ b/1.0/App42-Xamarin-SDK/Upload.cs
@@ -78,6 +78,8 @@ namespace com.shephertz.app42.paas.sdk.csharp.upload
             {
                 this.userName = userName;
             }
+
+            #warning this one hides .net default method .GetType()!
             /// <summary>
             /// Returns the type of the Upload File.
             /// </summary>

--- a/1.0/App42-Xamarin-SDK/packages.config
+++ b/1.0/App42-Xamarin-SDK/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Newtonsoft.Json" version="7.0.1" targetFramework="net45" />
+</packages>


### PR DESCRIPTION
This pull request fixes reference to Newtonsoft.Json (adds it from Nuget) - before Newtonsoft.Json was referenced from "C:\Users\Suyash\Downloads\Newtonsoft.Json.dll" which not all the developers have

Also, as I was able to compile the SDK, I saw some warnings due to incorrect usage of ToString() method so I fixed them as well.

Still there is some work to do because some classes are declaring method .GetType() which is one of the basic .NET/Mono methods in any class. 
